### PR TITLE
Un formulaire de recherche plus simple et joli

### DIFF
--- a/actions/NewTextSearchAction__.php
+++ b/actions/NewTextSearchAction__.php
@@ -40,7 +40,7 @@ class NewTextSearchAction__ extends YesWikiAction
             // largeur de la zone de saisie
             'size' => isset($arg['size']) && is_scalar($arg['size']) ? intval($arg['size']) : 40,
             // texte du bouton
-            'button' => !empty($arg['button']) && is_string($arg['button']) ? $arg['button'] : _t('SEARCH'),
+            'button' => !empty($arg['button']) && is_string($arg['button']) ? $arg['button'] : '&#xf002;', // search icon
             // texte à chercher
             'phrase' => isset($arg['phrase']) && is_string($arg['phrase']) ? $arg['phrase'] : '',
             // séparateur entre les éléments trouvés

--- a/actions/NewTextSearchAction__.php
+++ b/actions/NewTextSearchAction__.php
@@ -39,8 +39,6 @@ class NewTextSearchAction__ extends YesWikiAction
             'label' => isset($arg['label']) && is_string($arg['label']) ? $arg['label'] : _t('WHAT_YOU_SEARCH')." : ",
             // largeur de la zone de saisie
             'size' => isset($arg['size']) && is_scalar($arg['size']) ? intval($arg['size']) : 40,
-            // texte du bouton
-            'button' => !empty($arg['button']) && is_string($arg['button']) ? $arg['button'] : '&#xf002;', // search icon
             // texte à chercher
             'phrase' => isset($arg['phrase']) && is_string($arg['phrase']) ? $arg['phrase'] : '',
             // séparateur entre les éléments trouvés

--- a/javascripts/advancedsearch-dynamic.js
+++ b/javascripts/advancedsearch-dynamic.js
@@ -734,7 +734,7 @@ let appParams = {
         if (this.textInput && this.textInput != undefined) {
             this.searchText = this.textInput.val();
             $(this.textInput).on('change',()=>this.updateSearchText());
-            $(this.textInput).parent().find('input[type=submit]').on('click',(event)=>{
+            $(this.textInput).parent().find('button[type=submit]').on('click',(event)=>{
                 event.preventDefault();
                 this.updateSearchText();
             });

--- a/services/ActionsBuilderService.php
+++ b/services/ActionsBuilderService.php
@@ -80,11 +80,6 @@ trait ActionsBuilderServiceCommon
                     'default' => "40",
                     'min' => '1',
                 ];
-                $this->data['action_groups']['advanced-actions']['actions']['newtextsearch']['properties']['button'] = [
-                    'label' => _t('AB_advanced_action_textsearch_button_label'),
-                    'type' => "text",
-                    'default' => _t('SEARCH'),
-                ];
                 $this->data['action_groups']['advanced-actions']['actions']['newtextsearch']['properties']['template'] = [
                     'label' => _t('AB_advanced_action_newtextsearch_template_label'),
                     'type' => "list",

--- a/services/AdvancedSearchService.php
+++ b/services/AdvancedSearchService.php
@@ -394,19 +394,18 @@ class AdvancedSearchService
                 $reverseNeedle = $this->reverseNeedle($needle);
                 $currentSearches = [];
                 if ($fastMode){
-                    $currentSearches[] = "body LIKE '$reverseNeedle'";
                     $search = $this->convertToRawJSONStringForREGEXP($reverseNeedle);
-                    $currentSearches[] = "body REGEXP '$search'";
+                    $currentSearches[] = "body REGEXP '\\\\b$search\\\\b'";
                 } else {
                     // add regexp standard search in page not entries
                     $needleFormatted = $this->prepareNeedleForRegexpCaseInsensitive($needle);
                     $search = str_replace('_', '\\_', $needleFormatted);
-                    $currentSearches[] = "body REGEXP '$search'";
-    
+                    $currentSearches[] = "body REGEXP '\\\\b$search\\\\b'";
+
                     // add regexp standard search for entries
                     $search = $this->convertToRawJSONStringForREGEXP($needleFormatted);
                     $search = str_replace('_', '\\_', $search);
-                    $currentSearches[] = "body REGEXP '$search'";
+                    $currentSearches[] = "body REGEXP '\\\\b$search\\\\b'";
                 }
 
                 if (!$fastMode && !empty($results)) {

--- a/services/AdvancedSearchService.php
+++ b/services/AdvancedSearchService.php
@@ -394,18 +394,19 @@ class AdvancedSearchService
                 $reverseNeedle = $this->reverseNeedle($needle);
                 $currentSearches = [];
                 if ($fastMode){
+                    $currentSearches[] = "body LIKE '$reverseNeedle'";
                     $search = $this->convertToRawJSONStringForREGEXP($reverseNeedle);
-                    $currentSearches[] = "body REGEXP '\\\\b$search\\\\b'";
+                    $currentSearches[] = "body REGEXP '$search'";
                 } else {
                     // add regexp standard search in page not entries
                     $needleFormatted = $this->prepareNeedleForRegexpCaseInsensitive($needle);
                     $search = str_replace('_', '\\_', $needleFormatted);
-                    $currentSearches[] = "body REGEXP '\\\\b$search\\\\b'";
+                    $currentSearches[] = "body REGEXP '$search'";
 
                     // add regexp standard search for entries
                     $search = $this->convertToRawJSONStringForREGEXP($needleFormatted);
                     $search = str_replace('_', '\\_', $search);
-                    $currentSearches[] = "body REGEXP '\\\\b$search\\\\b'";
+                    $currentSearches[] = "body REGEXP '$search'";
                 }
 
                 if (!$fastMode && !empty($results)) {

--- a/styles/advancedsearch.css
+++ b/styles/advancedsearch.css
@@ -51,6 +51,13 @@ p.search-results > i {
   background-color: var(--primary-color);
   color: var(--neutral-light-color);
   z-index: 0 !important;
+  font-family: "Font Awesome 5 Free";
+  font-weight: 900
+}
+
+.search-form .input-group .form-control {
+    border-radius: 5px 0 0 5px !important;
+    font-size: 1em;
 }
 
 .input-group-lg > .form-control, .input-group-lg > .input-group-addon, 

--- a/templates/core/newtextsearch.twig
+++ b/templates/core/newtextsearch.twig
@@ -16,7 +16,7 @@
       <span class="input-group-btn input-group-addon">
         <button
           type="submit" 
-          class="btn btn-search">>{{ args.button | raw }}</button>
+          class="btn btn-search">>&#xf002;</button>
       </span>
     </div>
   </form>

--- a/templates/core/newtextsearch.twig
+++ b/templates/core/newtextsearch.twig
@@ -16,7 +16,7 @@
       <span class="input-group-btn input-group-addon">
         <button
           type="submit" 
-          class="btn btn-search">>&#xf002;</button>
+          class="btn btn-search">&#xf002;</button>
       </span>
     </div>
   </form>

--- a/templates/core/newtextsearch.twig
+++ b/templates/core/newtextsearch.twig
@@ -6,8 +6,7 @@
 {% if displayForm %}
   <form action="{{ url({method:""}) }}" method="get" class="search-form">
     <div class="input-prepend input-append input-group input-group-lg">
-      <span class="add-on input-group-addon"><i class="fa fa-search icon-search"></i></span>
-      <input 
+      <input
           name="phrase" 
           type="text" 
           class="form-control" 
@@ -15,10 +14,9 @@
           size="{{ args.size }}"
           value="{{ searchText }}" >
       <span class="input-group-btn input-group-addon">
-        <input 
+        <button
           type="submit" 
-          class="btn btn-search" 
-          value="{{ args.button }}" />
+          class="btn btn-search">&#xf002;</button>
       </span>
     </div>
   </form>

--- a/templates/core/newtextsearch.twig
+++ b/templates/core/newtextsearch.twig
@@ -16,7 +16,7 @@
       <span class="input-group-btn input-group-addon">
         <button
           type="submit" 
-          class="btn btn-search">&#xf002;</button>
+          class="btn btn-search">>{{ args.button | raw }}</button>
       </span>
     </div>
   </form>

--- a/templates/core/search-in-other-page.twig
+++ b/templates/core/search-in-other-page.twig
@@ -8,10 +8,11 @@
     <div class="bazar-search control-group">
       <input type="hidden" value="" name="{{ linkedPage ~ (url({tag:linkedPage}) matches '/iframe$/' ? '/iframe' : '') }}" />
       <div class="input-group input-prepend input-append">
-        <span class="add-on input-group-addon"><i class="fa fa-search icon-search"></i></span>
         <input type="text" value="{{ keywords }}" name="phrase" placeholder="{{ _t('BAZ_MOT_CLE') }}" class="search-input form-control input-lg">
         <span class="input-group-btn search-button-container">
-          <input value="{{ _t('BAZ_RECHERCHER') }}" class="btn btn-primary" type="submit" />
+          <button
+              type="submit"
+              class="btn btn-search">{{ args.button | raw }}</button>
         </span>
       </div>
     </div>

--- a/templates/core/search-in-other-page.twig
+++ b/templates/core/search-in-other-page.twig
@@ -12,7 +12,7 @@
         <span class="input-group-btn search-button-container">
           <button
               type="submit"
-              class="btn btn-search">{{ args.button | raw }}</button>
+              class="btn btn-search">&#xf002;</button>
         </span>
       </div>
     </div>


### PR DESCRIPTION
La PR a permet d'avoir un formulaire de recherche plus sympa : pas d'icône à gauche et une icône loupe sur le bouton de droite.

Au départ, j'avais gardé l'argument `button` pour laisser la possibilité de le paramétrer mais ensuite je me suis rendu compte que je devais mettre la police fontawesome pour l'icône. Le texte se lit mais ça fait bizarre car on n'a pas la police du site du bouton mais une police style serif.

Au final, ça rend la configuration plus simple et il y a toujours possibilité de changer le rendu en css si on veut customiser.